### PR TITLE
Params for /Messages should be query string params not body

### DIFF
--- a/message.go
+++ b/message.go
@@ -119,7 +119,18 @@ func (s *MessageService) List(params MessageListParams) ([]Message, *Response, e
 	u := s.client.EndPoint("Messages")
 	v := structToUrlValues(&params)
 
-	req, _ := s.client.NewRequest("GET", u.String(), strings.NewReader(v.Encode()))
+	req, _ := s.client.NewRequest("GET", u.String(), nil)
+
+	// params are url query params
+	q := req.URL.Query()
+	for k, vals := range v {
+		for _, v := range vals {
+			if v != "" { // only set for non blank values
+				q.Add(k, v)
+			}
+		}
+	}
+	req.URL.RawQuery = q.Encode()
 
 	// Helper struct for handling the listing
 	type list struct {


### PR DESCRIPTION
Twilio does not parse body params for the `GET /Messages` call, rather, they're parsed as URL query params. So the current implementation actually passes no params to Twilio and so it always returns the full, unfiltered, list of messages. This PR fixes this to correctly pass the query filter params
